### PR TITLE
work with apache2 cookbook instead of breaking

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -21,6 +21,12 @@ suites:
   - name: default
     run_list:
       - 'recipe[cobblerd::default]'
+  - name: apache2
+    run_list:
+      - 'recipe[cobblerd::default]'
+    attributes:
+      cobbler:
+        include_apache2: true
   - name: images
     run_list:
       - 'recipe[cobblerd::centos]'

--- a/metadata.rb
+++ b/metadata.rb
@@ -16,5 +16,6 @@ supports 'ubuntu', '= 12.04'
 supports 'ubuntu', '= 14.04'
 
 depends 'poise', '~> 1.0'
-recommends 'apt', '~> 2.4'
-recommends 'yum-epel', '~> 0.3'
+depends 'apt', '~> 2.4'
+depends 'yum-epel', '~> 0.3'
+depends 'apache2'

--- a/recipes/apache.rb
+++ b/recipes/apache.rb
@@ -1,0 +1,13 @@
+include_recipe 'apache2'
+include_recipe 'apache2::mod_proxy'
+include_recipe 'apache2::mod_proxy_http'
+
+apache_module 'wsgi'
+
+web_app "cobbler" do
+  template "cobbler.conf.erb"
+end
+
+service 'httpd' do
+  action [:enable, :start]
+end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -6,8 +6,10 @@
 #
 include_recipe 'yum-epel::default' if node[:platform_family] == "rhel"
 include_recipe 'apt::default' if node[:platform_family] == "debian"
+include_recipe 'cobblerd::apache' if node[:cobbler][:include_apache2]
 
 package 'cobbler'
+package 'syslinux'
 
 service 'cobbler' do
   action [:enable, :start]

--- a/templates/default/cobbler.conf.erb
+++ b/templates/default/cobbler.conf.erb
@@ -1,0 +1,38 @@
+# This configuration file allows cobbler data
+# to be accessed over HTTP.
+<VirtualHost *:80>
+AliasMatch ^/cblr(?!/svc/)(.*)?$ "/var/www/cobbler"
+AliasMatch ^/cobbler_track(.*)?$ "/var/www/cobbler"
+#AliasMatch ^/cobbler(.*)?$ "/var/www/cobbler"
+Alias /cobbler /var/www/cobbler
+Alias /cobbler_webui_content /var/www/cobbler_webui_content
+
+WSGIScriptAliasMatch ^/cblr/svc/([^/]*) /var/www/cobbler/svc/services.py
+
+<Directory "/var/www/cobbler">
+    Options Indexes FollowSymLinks
+    Order allow,deny
+    Allow from all
+</Directory>
+
+ProxyRequests off
+
+ProxyPass /cobbler_api http://localhost:25151/
+ProxyPassReverse /cobbler_api http://localhost:25151/
+<Location /cobbler_api>
+  Order allow,deny
+  Allow from all
+</Location>
+
+BrowserMatch "MSIE" AuthDigestEnableQueryStringHack=On
+
+# the webui is now part of the "cobbler-web" package
+# and is visited at http://.../cobbler_web not this URL.
+# this is only a pointer to the new page.
+
+<Directory "/var/www/cobbler/web/">
+    Options Indexes FollowSymLinks
+    Order allow,deny
+    Allow from all
+</Directory>
+</VirtualHost>


### PR DESCRIPTION
This adds a recipe to include if the box happens to also include the apache2 recipe somewhere, set the attribute node[:cobbler][:include_apache2] to make it setup the apache2 cookbook correctly to work with cobbler.