### PR TITLE
Oops it appears that CentOS 6.7 also uses the service name cobblerd

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -12,7 +12,7 @@ package 'cobbler'
 service 'cobbler' do
   case node['platform']
     when 'centos','redhat','fedora'
-      if node['platform_version'].to_i > 6
+      if node['platform_version'].to_i >= 6
         service_name 'cobblerd'
       end
   end


### PR DESCRIPTION
This adds an equality for all RHEL/CentOS versions less than _or equal to_ `6` from #1, as it seems CentOS 6.7 is failing due to the wrong service name too.