### PR TITLE
Update default.rb

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -21,7 +21,7 @@ service 'cobbler' do
 end
 
 # define cobbler sync for actions which need it
-bash 'cobbler-sync' do
+execute 'cobbler-sync' do
   command 'cobbler sync'
   action :nothing
 end


### PR DESCRIPTION
change bash resource to execute. 

Error from chef compile:
      ================================================================================
      Recipe Compile Error in /tmp/kitchen/cache/cookbooks/optum_test_kitchen/recipes/default.rb
      ================================================================================

      Chef::Exceptions::Script
      ------------------------
      Do not use the command attribute on a bash resource, use the 'code' attribute instead.

      Cookbook Trace:
      ---------------
        /tmp/kitchen/cache/cookbooks/cobblerd/recipes/default.rb:25:in `block in from_file'
        /tmp/kitchen/cache/cookbooks/cobblerd/recipes/default.rb:24:in `from_file'
        /tmp/kitchen/cache/cookbooks/optum_test_kitchen/recipes/default.rb:6:in `from_file'

      Relevant File Content:
      ----------------------