### PR TITLE
Update to 2.8.3, use checkinstall to create deb

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -27,7 +27,7 @@ default['cobbler']['grub']['uefi_signed']['url'] = 'http://archive.ubuntu.com/ub
 
 # Cobbler git repo and revision
 default[:cobbler][:repo][:url] = 'https://github.com/cobbler/cobbler'
-default[:cobbler][:repo][:tag] = 'v2.6.10'
+default[:cobbler][:repo][:tag] = 'v2.8.3'
 
 # Whether to install from local package type or remote repository
 default['cobbler']['package']['type'] = 'local'


### PR DESCRIPTION
* Update from Cobbler 2.6.x to 2.8.3 for Ubuntu 18.04 support
* Cobbler 2.8 no longer has working Debian package scripts, so use checkinstall instead.
