### PR TITLE
[WIP] - Use Xenial HWE netboot image for Trusty

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Installs and configures [Cobbler][1] and Cobbler Web.
 
 ## Supported Platforms
 - CentOS 6.5, 5.10
-- Ubuntu 12.04, 14.04
+- Ubuntu 14.04
 
 ## Attributes
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,5 +1,5 @@
 Vagrant.configure('2') do |config|
-  config.vm.box = ENV.fetch('VAGRANT_BOX_NAME', 'opscode-ubuntu-12.04')
+  config.vm.box = ENV.fetch('VAGRANT_BOX_NAME', 'ubuntu/trusty64')
 
   config.omnibus.chef_version = :latest if Vagrant.has_plugin?('vagrant-omnibus')
   config.berkshelf.enabled = true if Vagrant.has_plugin?('vagrant-berkshelf')

--- a/metadata.rb
+++ b/metadata.rb
@@ -12,7 +12,6 @@ version          '0.4.0'
   supports name, '~> 7.0'
 end
 
-supports 'ubuntu', '= 12.04'
 supports 'ubuntu', '= 14.04'
 
 depends 'poise'

--- a/recipes/ubuntu.rb
+++ b/recipes/ubuntu.rb
@@ -8,17 +8,6 @@ include_recipe 'cobblerd::default'
 
 profile = 'ubuntu'
 
-cobbler_image 'ubuntu-12.04-minimal' do
-  source 'http://archive.ubuntu.com/ubuntu/dists/precise/main/installer-amd64/current/images/netboot/mini.iso'
-  checksum '7df121f07878909646c8f7862065ed7182126b95eadbf5e1abb115449cfba714'
-  kernel 'http://archive.ubuntu.com/ubuntu/dists/precise-updates/main/installer-amd64/current/images/saucy-netboot/ubuntu-installer/amd64/linux'
-  kernel_checksum '4664511047fc3d7d5d13be77a86141be05dca283b50a3a51fd3c0638ab72816d'
-  initrd 'http://archive.ubuntu.com/ubuntu/dists/precise-updates/main/installer-amd64/current/images/saucy-netboot/ubuntu-installer/amd64/initrd.gz'
-  initrd_checksum 'dbc5dafc6a4eb5f0c22fe85a79185d3761b76871b6501d82043361d5f3cc8e6d'
-  os_version 'precise'
-  os_breed 'ubuntu'
-end
-
 cobbler_image 'ubuntu-14.04-minimal' do
   source 'http://archive.ubuntu.com/ubuntu/dists/trusty-updates/main/installer-amd64/current/images/xenial-netboot/mini.iso'
   checksum 'eefab8ae8f25584c901e6e094482baa2974e9f321fe7ea7822659edeac279609'
@@ -26,7 +15,7 @@ cobbler_image 'ubuntu-14.04-minimal' do
   os_breed 'ubuntu'
 end
 
-%w{ubuntu-12.04-minimal ubuntu-14.04-minimal}.each do |dist|
+%w{ubuntu-14.04-minimal}.each do |dist|
   cobbler_profile "#{profile}-#{dist}" do
     kickstart "#{profile}.preseed"
     distro "#{dist}-x86_64"

--- a/recipes/ubuntu.rb
+++ b/recipes/ubuntu.rb
@@ -20,8 +20,8 @@ cobbler_image 'ubuntu-12.04-minimal' do
 end
 
 cobbler_image 'ubuntu-14.04-minimal' do
-  source 'http://archive.ubuntu.com/ubuntu/dists/trusty/main/installer-amd64/current/images/netboot/mini.iso'
-  checksum 'bc09966b54f91f62c3c41fc14b76f2baa4cce48595ce22e8c9f24ab21ac8d965'
+  source 'http://archive.ubuntu.com/ubuntu/dists/trusty-updates/main/installer-amd64/current/images/xenial-netboot/mini.iso'
+  checksum 'eefab8ae8f25584c901e6e094482baa2974e9f321fe7ea7822659edeac279609'
   os_version 'trusty'
   os_breed 'ubuntu'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -37,7 +37,7 @@ RSpec.shared_context 'recipe tests', type: :recipe do
   def node_attributes
     {
       platform: 'ubuntu',
-      version: '12.04'
+      version: '14.04'
     }
   end
 end


### PR DESCRIPTION
**DO NOT MERGE YET**

Still need to test this to verify it's really working as expected, but the gist of this change is:

1. Move from the standard 14.04 image to the current Xenial HWE one. 
2. Remove 12.04.

This needs some verification and testing before I'll remove the WIP tag from the subject.