### PR TITLE
Checkinstall fixes

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -9,8 +9,6 @@ platforms:
   - name: ubuntu-14.04
     run_list:
       - 'recipe[apt::default]'
-  - name: centos-6.7
-  - name: centos-7.2
 suites:
   - name: cobbler_source_build
     attributes: {

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -13,7 +13,7 @@
   end
 end
 
-%w(/var/www/cobbler /var/lib/tftpboot).each do |dir|
+%w(/var/log/cobbler/tasks /var/www/cobbler /var/lib/tftpboot).each do |dir|
   directory dir do
     owner 'root'
     group 'root'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -5,7 +5,7 @@
 # Copyright (C) 2015 Bloomberg Finance L.P.
 #
 
-%w(loaders tasks config/distros.d config/profiles.d config/repos.d).each do |dir|
+%w(loaders tasks config/distros.d config/profiles.d config/repos.d config/systems.d).each do |dir|
   directory File.join('/var/lib/cobbler/', dir) do
     owner 'root'
     group 'root'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -5,6 +5,22 @@
 # Copyright (C) 2015 Bloomberg Finance L.P.
 #
 
+%w(loaders tasks config/distros.d config/profiles.d config/repos.d).each do |dir|
+  directory File.join('/var/lib/cobbler/', dir) do
+    owner 'root'
+    group 'root'
+    recursive true
+  end
+end
+
+%w(/var/www/cobbler /var/lib/tftpboot).each do |dir|
+  directory dir do
+    owner 'root'
+    group 'root'
+    recursive true
+  end
+end
+
 service node['cobbler']['service']['name'] do
   action [:enable, :start]
   supports restart: true


### PR DESCRIPTION
This gets Chef-BACH to install and addresses the immediate breakage mentioned in #13 but has not fixed cobbler putting bits all over the file system in unexpected ways. E.g. bits are ending up in /srv/www instead of /var/www/cobbler (which may suggest an issue with where Cobbler is looking for [settings.py](https://github.com/bloomberg/chef-bach/blob/7f88bb76ed442f36b7ea8f85aa095564b9210920/cookbooks/bcpc/templates/default/cobbler/settings.erb#L369) as Chef-BACH specifies the `webdir` entry there to be under /var.

@http-418, perhaps you can take a look and see what other fixes are necessary to make #10 usable and testable again as @aceofsteel can give you time?